### PR TITLE
allow make to succeed without git

### DIFF
--- a/makefile
+++ b/makefile
@@ -56,15 +56,19 @@ else
 	@echo "Literate support code already present"
 endif
 
+# variable that will exist of git command exists
+# solution from: http://stackoverflow.com/questions/5618615/check-if-a-program-exists-from-a-makefile
+GIT_EXISTS := $(shell command -v git 2> /dev/null)
 
 # get the latest commit hash and its subject line
 # and write that to the VERSION file
 write-version:
-	echo -n "Built from commit: " > ${CODE_DIR}/${VER_FILE}
+ifdef GIT_EXISTS
 	# allow these to fail since the parent folder may not have a git repo.
+	echo -n "Built from commit: " > ${CODE_DIR}/${VER_FILE}
 	- echo `git rev-parse HEAD` >> ${CODE_DIR}/${VER_FILE}
 	- echo `git log --pretty=format:'%s' -n 1` >> ${CODE_DIR}/${VER_FILE}
-
+endif
 clean-literate:
 	rm -rf ${ELISP_DIR}
 	rm -rf src/${ORG_DIR}

--- a/makefile
+++ b/makefile
@@ -61,8 +61,9 @@ endif
 # and write that to the VERSION file
 write-version:
 	echo -n "Built from commit: " > ${CODE_DIR}/${VER_FILE}
-	echo `git rev-parse HEAD` >> ${CODE_DIR}/${VER_FILE}
-	echo `git log --pretty=format:'%s' -n 1` >> ${CODE_DIR}/${VER_FILE}
+	# allow these to fail since the parent folder may not have a git repo.
+	- echo `git rev-parse HEAD` >> ${CODE_DIR}/${VER_FILE}
+	- echo `git log --pretty=format:'%s' -n 1` >> ${CODE_DIR}/${VER_FILE}
 
 clean-literate:
 	rm -rf ${ELISP_DIR}


### PR DESCRIPTION
I changed the `makefile` to allow `literate-tools` to be used even in folders that are not git folders. The current tool runs `rev-parse` and `git log --pretty` which need not exist.

Ping @vxc 